### PR TITLE
Correct certificate storage lookup order for FreeBSD

### DIFF
--- a/HsOpenSSL-x509-system.cabal
+++ b/HsOpenSSL-x509-system.cabal
@@ -1,5 +1,5 @@
 name:                HsOpenSSL-x509-system
-version:             0.1.0.3
+version:             0.1.0.4
 synopsis:            Use the system's native CA certificate store with HsOpenSSL
 description:
   A cross-platform library that tries to find a (reasonable) CA certificate

--- a/OpenSSL/X509/SystemStore/Unix.hs
+++ b/OpenSSL/X509/SystemStore/Unix.hs
@@ -36,8 +36,8 @@ defaultSystemPaths =
     [ (False, "/etc/pki/tls/certs/ca-bundle.crt"      ) -- red hat, fedora. centos
     , (True , "/etc/ssl/certs"                        ) -- other linux, netbsd
     , (True , "/system/etc/security/cacerts"          ) -- android
+    , (False, "/usr/local/share/certs/ca-root-nss.crt") -- freebsd (security/ca-root-nss)
     , (True , "/usr/local/share/certs"                ) -- freebsd
     , (False, "/etc/ssl/cert.pem"                     ) -- openbsd
     , (False, "/usr/share/ssl/certs/ca-bundle.crt"    ) -- older red hat
-    , (False, "/usr/local/share/certs/ca-root-nss.crt") -- freebsd (security/ca-root-nss)
     ]


### PR DESCRIPTION
Previously on FreeBSD the path `/usr/local/share/certs` was found first and caused the main lookup loop (in `contextLoadSystemCerts` in Unix.hs) to exit. Since this directory only contains one certificate bundle and not single certificates, the loop exited and no certificates were loaded. By altering the order of the search paths, the root certs are recognized correctly on FreeBSD.

This issue appeared while using `hookup` together with `irc-core`. It worked perfectly fine on GNU/Linux but when moving it to FreeBSD no connection could be established.

Confirmed to be working on FreeBSD 12.1-RELEASE-p8 amd64 and GNU/Linux Archlinux 5.4.57-lts x86_64.

Please tell me if any issues arise from this.