### PR TITLE
.cabal: use extra-doc-files for ChangeLog.md

### DIFF
--- a/HsOpenSSL-x509-system.cabal
+++ b/HsOpenSSL-x509-system.cabal
@@ -16,9 +16,9 @@ author:              Marios Titas <rednebΑΤgmxDΟΤcom>
 maintainer:          Marios Titas <rednebΑΤgmxDΟΤcom>
 category:            System, Filesystem
 build-type:          Simple
-cabal-version:       >=1.10
+cabal-version:       1.18
 
-extra-source-files:
+extra-doc-files:
   ChangeLog.md
 
 source-repository head


### PR DESCRIPTION
requires Cabal 1.18

This also prevents cabal 2 from making ChangeLog.md executable (a cabal bug),
like in HsOpenSSL-x509-system-0.1.0.4.tar.gz